### PR TITLE
fix for micronaut >=v2.2.0

### DIFF
--- a/sample-micronaut-oauth2/src/main/resources/application.yml
+++ b/sample-micronaut-oauth2/src/main/resources/application.yml
@@ -19,6 +19,8 @@ micronaut:
       grant-type: password
       client-id: micronaut
       client-secret: 4ccb59cc-8c56-4e76-b87a-e3d5efc8704a
+      openid:
+        issuer: http://localhost:8888/auth/realms/master
       authorization:
         url: http://localhost:8888/auth/realms/master/protocol/openid-connect/auth
       token:


### PR DESCRIPTION
This example project no longer works with micronaut >= v2.2.0 which has additional restrictions for idtoken authentication
[see](https://github.com/micronaut-projects/micronaut-security/releases/tag/v2.2.0)
The application.yml needs to specify the openid issuer which needs to match the one in the obtained token.
Additionaly keycloak configuration needs to include the client-id (micronaut) in the "aud" of the token